### PR TITLE
Added parseKeyValuePairs method in RequestParser Class

### DIFF
--- a/src/main/java/httpserver/request/RequestParser.java
+++ b/src/main/java/httpserver/request/RequestParser.java
@@ -14,7 +14,7 @@ public class RequestParser {
     private String version;
     private String body = "";
 
-    public  RequestParser(String incomingData) {
+    public RequestParser(String incomingData) {
         this.incomingRequest = incomingData;
     }
 
@@ -39,25 +39,14 @@ public class RequestParser {
     }
 
     public String getRequestVersion() {
-        return incomingRequest.split(SP)[2];
+        return incomingRequest.split(SP, 0)[2];
     }
 
     public HashMap<String, String> getRequestHeaders() {
-        String[] headerArray = incomingRequest.split(CRLF);
-        for (int i = 1; i < headerArray.length; i++) {
-            String[] headerPair = headerArray[i].split(": ");
-            if (headerPair.length == 2) {
-                String key = headerPair[0];
-                String value;
-                if (i == headerArray.length - 1) {
-                    value = headerPair[1].split(CRLF + CRLF, 2)[0];
-                } else {
-                    value = headerPair[1];
-                }
-                this.headers.put(key, value);
-            }
-        }
-        return headers;
+        //This will create a string array seperated by CRLF
+        // where each element is one line of the request
+        String[] requestString = incomingRequest.split(CRLF);
+        return parseKeyValuePairs(requestString, headers);
     }
 
     public String getRequestBody() {
@@ -65,4 +54,25 @@ public class RequestParser {
     }
 
 
+    public HashMap<String, String> parseKeyValuePairs(
+            String[] requestString, HashMap<String, String> headers) {
+        //Iterate through the string array starting
+        // from the second line of the string
+        for (int i = 1; i < requestString.length; i++) {
+            String[] headerPair = requestString[i].split(": ");
+            if (headerPair.length == 2) {
+                String key = headerPair[0];
+                String value;
+                if (i == requestString.length - 1) {
+                    value = headerPair[1].split(CRLF + CRLF, 2)[0];
+                } else {
+                    value = headerPair[1];
+                }
+                headers.put(key, value);
+            }
+        }
+        return headers;
+    }
+
 }
+

--- a/src/test/java/httpserver/TestUtils.java
+++ b/src/test/java/httpserver/TestUtils.java
@@ -12,9 +12,9 @@ import static httpserver.constants.StatusCode.OK;
 public class TestUtils {
 
     public static String mockRequestData() {
-        return "POST /echo_body HTTP/1.1 \n" + "Connection: close\n" +
-                "Host: 127.0.0.1:5000\n" + "User-Agent: http.rb/4.3.0\n" +
-                "Content-Length: 9\r\n" + "\r\n" + "some body";
+        return "POST /echo_body HTTP/1.1 " + CRLF + "Connection: close" + CRLF +
+                "Host: 127.0.0.1:5000" + CRLF + "User-Agent: http.rb/4.3.0" +
+                CRLF + "Content-Length: 9" + CRLF + CRLF + "some body";
     }
 
     public static String mockEchoData() {
@@ -63,4 +63,5 @@ public class TestUtils {
     }
 
 }
+
 

--- a/src/test/java/httpserver/request/RequestParserTest.java
+++ b/src/test/java/httpserver/request/RequestParserTest.java
@@ -5,11 +5,14 @@ import httpserver.TestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 
+import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RequestParserTest {
     RequestParser requestParser;
+    HashMap<String, String> testHeaders;
 
 
     public void initialize() {
@@ -44,6 +47,32 @@ class RequestParserTest {
         assertEquals(requestParser.getRequestBody(), "some body");
     }
 
+    @Test
+    @DisplayName("Test if the server received the correct headers")
+    public void testIfServerRetrievedCorrectRequestHeaders() {
+        initialize();
+        testHeaders = requestParser.getRequestHeaders();
+        assertEquals(testHeaders.containsKey("Content-Length"), true);
+        assertEquals(testHeaders.containsKey("Host"), true);
+        assertEquals(testHeaders.containsKey("Connection"), true);
+    }
+
+    @Test
+    @DisplayName("Test if parseKeyValuePairs add keys and values to map")
+    public void testIfParseKeyValuePairsAddsKeyValuesToMap() {
+        String incomingData = TestUtils.mockEchoData();
+
+        //Check if the map is empty
+        requestParser = new RequestParser(incomingData);
+        testHeaders = new HashMap<>();
+        assertEquals(testHeaders.isEmpty(), true);
+
+        //Check if values were added to the map
+        requestParser.parseKeyValuePairs(incomingData.split(CRLF), testHeaders);
+        assertEquals(testHeaders.isEmpty(), false);
+        assertEquals(testHeaders.containsKey("Connection"), true);
+    }
 }
+
 
 


### PR DESCRIPTION
- Extracted logic from `getRequestHeaders` and placed it inside a new function called `parseKeyValues`. This logic parses key-value pairs from the incoming request string and adds them to a hashmap.
- Renamed `headerArray`, to `requestString`
- Added tests for the new function
- Added test for getRequestHeaders function