### PR TITLE
Refactor data to bytes

### DIFF
--- a/src/main/java/httpserver/handlers/EchoHandler.java
+++ b/src/main/java/httpserver/handlers/EchoHandler.java
@@ -21,7 +21,7 @@ public class EchoHandler implements IHandler {
             return responseBuilder.withStatus(OK.code)
                     .withHeader("Allow: " + getAcceptedMethods())
                     .withHeader("Content-Length: " + request.body.length())
-                    .withBody(request.body).build();
+                    .withBody(request.body.getBytes()).build();
         } else {
             return responseBuilder.withStatus(METHOD_NOT_ALLOWED.code)
                     .withHeader("Allow: " + getAcceptedMethods()).build();

--- a/src/main/java/httpserver/handlers/HTMLResponse.java
+++ b/src/main/java/httpserver/handlers/HTMLResponse.java
@@ -25,7 +25,7 @@ public class HTMLResponse implements IHandler {
                     .withHeader("Allow: " + getAcceptedMethods())
                     .withHeader("Content-Type: text/html;charset=utf-8")
                     .withHeader("Content-Length: " + body.length())
-                    .withBody(body).build();
+                    .withBody(body.getBytes()).build();
         } else {
             return responseBuilder.withStatus(METHOD_NOT_ALLOWED.code)
                     .withHeader("Allow: " + getAcceptedMethods()).build();

--- a/src/main/java/httpserver/handlers/JSONResponse.java
+++ b/src/main/java/httpserver/handlers/JSONResponse.java
@@ -24,7 +24,7 @@ public class JSONResponse implements IHandler {
                     .withHeader("Allow: " + getAcceptedMethods())
                     .withHeader("Content-Type: application/json;charset=utf-8")
                     .withHeader("Content-Length: " + body.length())
-                    .withBody(body).build();
+                    .withBody(body.getBytes()).build();
         } else {
             return responseBuilder.withStatus(METHOD_NOT_ALLOWED.code)
                     .withHeader("Allow: " + getAcceptedMethods()).build();

--- a/src/main/java/httpserver/handlers/SimpleGet.java
+++ b/src/main/java/httpserver/handlers/SimpleGet.java
@@ -24,7 +24,7 @@ public class SimpleGet implements IHandler {
                     .withHeader("Allow: " + getAcceptedMethods());
             if (request.path.equals(SIMPLE_GET_WITH_BODY.path)) {
                 body = "Hello world";
-                responseBuilder.withBody(body);
+                responseBuilder.withBody(body.getBytes());
             }
             responseBuilder.withHeader("Content-Length: " + body.length());
             return responseBuilder.build();

--- a/src/main/java/httpserver/handlers/TextResponse.java
+++ b/src/main/java/httpserver/handlers/TextResponse.java
@@ -23,7 +23,7 @@ public class TextResponse implements IHandler {
                     .withHeader("Allow: " + getAcceptedMethods())
                     .withHeader("Content-Type: text/plain;charset=utf-8")
                     .withHeader("Content-Length: " + body.length())
-                    .withBody(body).build();
+                    .withBody(body.getBytes()).build();
         } else {
             return responseBuilder.withStatus(METHOD_NOT_ALLOWED.code)
                     .withHeader("Allow: " + getAcceptedMethods()).build();

--- a/src/main/java/httpserver/handlers/XMLResponse.java
+++ b/src/main/java/httpserver/handlers/XMLResponse.java
@@ -24,7 +24,7 @@ public class XMLResponse implements IHandler {
                     .withHeader("Allow: " + getAcceptedMethods())
                     .withHeader("Content-Type: application/xml;charset=utf-8")
                     .withHeader("Content-Length: " + body.length())
-                    .withBody(body).build();
+                    .withBody(body.getBytes()).build();
         } else {
             return responseBuilder.withStatus(METHOD_NOT_ALLOWED.code)
                     .withHeader("Allow: " + getAcceptedMethods()).build();

--- a/src/main/java/httpserver/interfaces/ISocket.java
+++ b/src/main/java/httpserver/interfaces/ISocket.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 public interface ISocket {
     String receiveData();
 
-    void sendData(String data) throws IOException;
+    void sendData(byte[] data) throws IOException;
 
     void close();
 }

--- a/src/main/java/httpserver/response/Response.java
+++ b/src/main/java/httpserver/response/Response.java
@@ -3,9 +3,9 @@ package httpserver.response;
 public class Response {
     public String status;
     public String headers;
-    public String body;
+    public byte[] body;
 
-    public Response(String status, String headers, String body) {
+    public Response(String status, String headers, byte[] body) {
         this.status = status;
         this.headers = headers;
         this.body = body;

--- a/src/main/java/httpserver/response/ResponseBuilder.java
+++ b/src/main/java/httpserver/response/ResponseBuilder.java
@@ -5,7 +5,7 @@ import static httpserver.constants.HTTPLines.CRLF;
 
 public class ResponseBuilder {
     private String status;
-    private String body = "";
+    private byte[] body;
     private String headers = "";
 
     public ResponseBuilder withStatus(String status) {
@@ -18,7 +18,7 @@ public class ResponseBuilder {
         return this;
     }
 
-    public ResponseBuilder withBody(String body) {
+    public ResponseBuilder withBody(byte[] body) {
         this.body = body;
         return this;
     }

--- a/src/main/java/httpserver/response/ResponseFormatter.java
+++ b/src/main/java/httpserver/response/ResponseFormatter.java
@@ -1,20 +1,35 @@
 package httpserver.response;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static httpserver.constants.HTTPLines.DEFAULT_VERSION;
 import static httpserver.constants.HTTPLines.SP;
 
 public class ResponseFormatter {
     public StringBuilder responseString = new StringBuilder();
+    byte[] formattedResponse;
 
-    public String formatResponse(Response response) {
+    public byte[] formatResponse(Response response) throws IOException {
+
         responseString.append(DEFAULT_VERSION + SP + response.status + CRLF);
+
         if (response.headers != "") {
             responseString.append(response.headers + CRLF);
         } else {
             responseString.append(CRLF);
         }
-        responseString.append(response.body);
-        return responseString.toString();
+
+        formattedResponse = responseString.toString().getBytes();
+
+        if (response.body == null) {
+            return formattedResponse;
+        }
+
+        ByteArrayOutputStream responseWithBody = new ByteArrayOutputStream();
+        responseWithBody.write(formattedResponse);
+        responseWithBody.write(response.body);
+        return responseWithBody.toByteArray();
     }
 }

--- a/src/main/java/httpserver/wrappers/SocketWrapper.java
+++ b/src/main/java/httpserver/wrappers/SocketWrapper.java
@@ -35,8 +35,8 @@ public class SocketWrapper implements ISocket {
     }
 
     @Override
-    public void sendData(String data) throws IOException {
-        output.write(data.getBytes());
+    public void sendData(byte[] data) throws IOException {
+        output.write(data);
         output.flush();
     }
 

--- a/src/test/java/httpserver/handlers/EchoHandlerTest.java
+++ b/src/test/java/httpserver/handlers/EchoHandlerTest.java
@@ -9,13 +9,16 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EchoHandlerTest {
     @Test
     @DisplayName("Test is the response echos the body")
-    public void testIfHandlerEchosBody() {
+    public void testIfHandlerEchosBody() throws IOException {
         IHandler echoHandler = new EchoHandler();
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockEchoData());
@@ -23,11 +26,13 @@ class EchoHandlerTest {
         Response response = echoHandler.handle(request);
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
-        String responseBody = responseFormatter.formatResponse(response)
-                .split(CRLF + CRLF, 2)[1];
+        String responseBody =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF + CRLF, 2)[1];
 
 
         assertEquals(responseBody, "some body");
     }
 
 }
+

--- a/src/test/java/httpserver/handlers/HTMLResponseTest.java
+++ b/src/test/java/httpserver/handlers/HTMLResponseTest.java
@@ -8,6 +8,9 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -20,7 +23,7 @@ class HTMLResponseTest {
 
     @Test
     @DisplayName("Should return the correct response with body")
-    public void testIfHandlerReturnsCorrectResponse() {
+    public void testIfHandlerReturnsCorrectResponse() throws IOException {
         HTMLResponse htmlResponseHandler = new HTMLResponse();
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockGetData("html_response"));
@@ -29,9 +32,11 @@ class HTMLResponseTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String htmlResponse =
-                responseFormatter.formatResponse(response);
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
 
         assertEquals(htmlResponse, textResponse);
     }
 }
+

--- a/src/test/java/httpserver/handlers/JSONResponseTest.java
+++ b/src/test/java/httpserver/handlers/JSONResponseTest.java
@@ -8,6 +8,9 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -20,7 +23,7 @@ class JSONResponseTest {
 
     @Test
     @DisplayName("Should return the correct response with body")
-    public void testIfHandlerReturnsCorrectResponse() {
+    public void testIfHandlerReturnsCorrectResponse() throws IOException {
         JSONResponse jsonResponseHandler = new JSONResponse();
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockGetData("json_response"));
@@ -30,8 +33,10 @@ class JSONResponseTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String jsonResponse =
-                responseFormatter.formatResponse(response);
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(jsonResponse, textResponse);
     }
 }
+

--- a/src/test/java/httpserver/handlers/NotAllowedTest.java
+++ b/src/test/java/httpserver/handlers/NotAllowedTest.java
@@ -8,13 +8,16 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NotAllowedTest {
     @Test
     @DisplayName("Should return 405 Method Not Allowed")
-    public void testIfHandlerSends405StatusLine() {
+    public void testIfHandlerSends405StatusLine() throws IOException {
         IHandler optionsHandler = new NotAllowed();
         RequestParser requestParser = new RequestParser(dummyData());
         Request request = requestParser.parse();
@@ -22,7 +25,8 @@ class NotAllowedTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String statusLine =
-                responseFormatter.formatResponse(response).split(CRLF)[0];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[0];
 
         assertEquals(statusLine, "HTTP/1.1 405 Method Not Allowed");
     }

--- a/src/test/java/httpserver/handlers/NotFoundTest.java
+++ b/src/test/java/httpserver/handlers/NotFoundTest.java
@@ -5,18 +5,22 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NotFoundTest {
     @Test
     @DisplayName("Test should return 404 Not Found")
-    public void testIfHandlerReturnsNotFound() {
+    public void testIfHandlerReturnsNotFound() throws IOException {
         NotFound notFound = new NotFound();
         Response response = notFound.handle();
         ResponseFormatter responseFormatter = new ResponseFormatter();
         String notFoundResponse =
-                responseFormatter.formatResponse(response);
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(notFoundResponse, "HTTP/1.1 404 Not Found" + CRLF + CRLF);
 

--- a/src/test/java/httpserver/handlers/OptionsTest.java
+++ b/src/test/java/httpserver/handlers/OptionsTest.java
@@ -8,13 +8,16 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OptionsTest {
     @Test
     @DisplayName("Should test for proper Status line")
-    public void testIfHandlerReturnsCorrectStatusLine() {
+    public void testIfHandlerReturnsCorrectStatusLine() throws IOException {
         IHandler optionsHandler = new Options();
         RequestParser requestParser = new RequestParser(dummyData());
         Request request = requestParser.parse();
@@ -23,13 +26,14 @@ class OptionsTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String statusLine =
-                responseFormatter.formatResponse(response).split(CRLF)[0];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[0];
         assertEquals(statusLine, "HTTP/1.1 200 OK");
     }
 
     @Test
     @DisplayName("Should test for proper Allow Header")
-    public void testIfHandlerReturnsCorrectAllowHeader() {
+    public void testIfHandlerReturnsCorrectAllowHeader() throws IOException {
         IHandler optionsHandler = new Options();
         RequestParser requestParser = new RequestParser(dummyData());
         Request request = requestParser.parse();
@@ -37,13 +41,15 @@ class OptionsTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String allowHeader =
-                responseFormatter.formatResponse(response).split(CRLF)[1];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[1];
         assertEquals(allowHeader, "Allow: GET, HEAD, OPTIONS");
     }
 
     @Test
     @DisplayName("Should test for proper Allow Header given Five Headers")
-    public void testIfHandlerReturnsAllowHeaderGivenFiveMethods() {
+    public void testIfHandlerReturnsAllowHeaderGivenFiveMethods()
+            throws IOException {
         IHandler optionsHandler = new OptionsTwo();
         RequestParser requestParser = new RequestParser(dummyData());
         Request request = requestParser.parse();
@@ -51,7 +57,8 @@ class OptionsTest {
         Response response = optionsHandler.handle(request);
         ResponseFormatter responseFormatter = new ResponseFormatter();
         String allowHeader =
-                responseFormatter.formatResponse(response).split(CRLF)[1];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[1];
 
         assertEquals(allowHeader, "Allow: GET, HEAD, OPTIONS, PUT, POST");
     }

--- a/src/test/java/httpserver/handlers/RedirectTest.java
+++ b/src/test/java/httpserver/handlers/RedirectTest.java
@@ -8,13 +8,16 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RedirectTest {
     @Test
     @DisplayName("Should return the appropriate Status Line response")
-    public void testIfHandlerReturnsCorrectStatusLine() {
+    public void testIfHandlerReturnsCorrectStatusLine() throws IOException {
         IHandler redirectHandler = new Redirect();
         RequestParser requestParser = new RequestParser(dummyData());
         Request request = requestParser.parse();
@@ -22,13 +25,14 @@ class RedirectTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String statusLine =
-                responseFormatter.formatResponse(response).split(CRLF)[0];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[0];
         assertEquals(statusLine, "HTTP/1.1 301 Moved Permanently");
     }
 
     @Test
     @DisplayName("Should return the Location Header with the correct url")
-    public void testIfHandlerReturnsTheCorrectHeader() {
+    public void testIfHandlerReturnsTheCorrectHeader() throws IOException {
         IHandler redirectHandler = new Redirect();
         RequestParser requestParser = new RequestParser(dummyData());
         Request request = requestParser.parse();
@@ -36,7 +40,8 @@ class RedirectTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String locationLine =
-                responseFormatter.formatResponse(response).split(CRLF)[2];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[2];
         assertEquals(locationLine,
                 "Location: http://127.0.0.1:5000/simple_get");
     }

--- a/src/test/java/httpserver/handlers/SimpleGetTest.java
+++ b/src/test/java/httpserver/handlers/SimpleGetTest.java
@@ -8,6 +8,9 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,7 +18,7 @@ class SimpleGetTest {
 
     @Test
     @DisplayName("Should return the response Status Line")
-    public void testIfHandlerReturnsStatusLine() {
+    public void testIfHandlerReturnsStatusLine() throws IOException {
         SimpleGet simpleGetHandler = new SimpleGet();
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockGetData("/simple_get"));
@@ -23,7 +26,9 @@ class SimpleGetTest {
         Response response = simpleGetHandler.handle(request);
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
-        String simpleGetResponse = responseFormatter.formatResponse(response);
+        String simpleGetResponse =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
 
         assertEquals(simpleGetResponse,
@@ -33,7 +38,7 @@ class SimpleGetTest {
 
     @Test
     @DisplayName("Should return the response with body")
-    public void testIfHandlerReturnsResponseWithBody() {
+    public void testIfHandlerReturnsResponseWithBody() throws IOException {
         SimpleGet simpleGetHandler = new SimpleGet();
         RequestParser requestParser = new RequestParser(
                 TestUtils.mockGetData("/simple_get_with_body"));
@@ -41,7 +46,9 @@ class SimpleGetTest {
         Response response = simpleGetHandler.handle(request);
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
-        String simpleGetResponse = responseFormatter.formatResponse(response);
+        String simpleGetResponse =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(simpleGetResponse,
                 "HTTP/1.1 200 OK" + CRLF + "Allow: GET, HEAD, OPTIONS, POST" +

--- a/src/test/java/httpserver/handlers/TextResponseTest.java
+++ b/src/test/java/httpserver/handlers/TextResponseTest.java
@@ -8,19 +8,22 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TextResponseTest {
 
     String textResponseToClient = "HTTP/1.1 200 OK" + CRLF
             + "Allow: GET, HEAD, OPTIONS" + CRLF
             + "Content-Type: text/plain;charset=utf-8" + CRLF
-            +  "Content-Length: 13" + CRLF + CRLF + "text response";
+            + "Content-Length: 13" + CRLF + CRLF + "text response";
 
     @Test
     @DisplayName("Should return the correct response with body")
-    public void testIfHandlerReturnsCorrectResponse() {
+    public void testIfHandlerReturnsCorrectResponse() throws IOException {
         TextResponse textResponseHandler = new TextResponse();
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockGetData("text_response"));
@@ -29,7 +32,8 @@ class TextResponseTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String textResponse =
-                responseFormatter.formatResponse(response);
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(textResponse, textResponseToClient);
     }

--- a/src/test/java/httpserver/handlers/XMLResponseTest.java
+++ b/src/test/java/httpserver/handlers/XMLResponseTest.java
@@ -8,20 +8,23 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class XMLResponseTest {
 
-    String xmlResponseText = "HTTP/1.1 200 OK" + CRLF
-            + "Allow: GET, HEAD, OPTIONS" + CRLF
-            + "Content-Type: application/xml;charset=utf-8" + CRLF
-            + "Content-Length: 38" + CRLF + CRLF +
-            "<note><body>XML Response</body></note>";
+    String xmlResponseText =
+            "HTTP/1.1 200 OK" + CRLF + "Allow: GET, HEAD, OPTIONS" + CRLF +
+                    "Content-Type: application/xml;charset=utf-8" + CRLF +
+                    "Content-Length: 38" + CRLF + CRLF +
+                    "<note><body>XML Response</body></note>";
 
     @Test
     @DisplayName("Should return the correct response with body")
-    public void testIfHandlerReturnsCorrectResponse() {
+    public void testIfHandlerReturnsCorrectResponse() throws IOException {
         XMLResponse xmlHandler = new XMLResponse();
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockGetData("xml_response"));
@@ -30,10 +33,12 @@ class XMLResponseTest {
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String xmlResponse =
-                responseFormatter.formatResponse(response);
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(xmlResponse, xmlResponseText);
     }
 
 
 }
+

--- a/src/test/java/httpserver/response/ResponseBuilderTest.java
+++ b/src/test/java/httpserver/response/ResponseBuilderTest.java
@@ -4,6 +4,9 @@ import httpserver.TestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static httpserver.constants.StatusCode.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,26 +14,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ResponseBuilderTest {
     @Test
     @DisplayName("It should return a StartLine with a Status off 200")
-    public void testIfBuilderReturnResponseWithOkStatus() {
+    public void testIfBuilderReturnResponseWithOkStatus() throws IOException {
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Response response = responseBuilder.withStatus(OK.code).build();
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String formattedResponse =
-                responseFormatter.formatResponse(response).split(CRLF, 2)[0];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF, 2)[0];
 
         assertEquals(formattedResponse, "HTTP/1.1 200 OK");
     }
 
     @Test
     @DisplayName("It should return a response with one header")
-    public void testIfBuilderReturnResponseWithHeaders() {
+    public void testIfBuilderReturnResponseWithHeaders() throws IOException {
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Response response = responseBuilder.withStatus(OK.code)
                 .withHeader("Content-Length: 0").build();
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
-        String formattedString = responseFormatter.formatResponse(response);
+        String formattedString =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(formattedString,
                 TestUtils.mockResponseWithContentLength("0"));
@@ -38,7 +44,8 @@ class ResponseBuilderTest {
 
     @Test
     @DisplayName("It should return a response with multiple headers")
-    public void testIfBuilderReturnResponseWithMultipleHeaders() {
+    public void testIfBuilderReturnResponseWithMultipleHeaders()
+            throws IOException {
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Response response = responseBuilder.withStatus(OK.code)
                 .withHeader("Content-Length: 0")
@@ -46,7 +53,9 @@ class ResponseBuilderTest {
 
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
-        String formattedString = responseFormatter.formatResponse(response);
+        String formattedString =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(formattedString,
                 TestUtils.mockResponseWithMultipleHeaders("0", ""));
@@ -54,16 +63,19 @@ class ResponseBuilderTest {
 
     @Test
     @DisplayName("It should return a response with multiple headers")
-    public void testIfBuilderReturnResponseWithBody() {
+    public void testIfBuilderReturnResponseWithBody() throws IOException {
         ResponseBuilder responseBuilder = new ResponseBuilder();
         String body = "some body";
         Response response = responseBuilder.withStatus(OK.code)
                 .withHeader("Content-Length: " + body.length())
-                .withHeader("Allow: GET, HEAD, OPTIONS").withBody(body).build();
+                .withHeader("Allow: GET, HEAD, OPTIONS")
+                .withBody(body.getBytes()).build();
 
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
-        String formattedString = responseFormatter.formatResponse(response);
+        String formattedString =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
 
         assertEquals(formattedString, TestUtils.mockResponseWithMultipleHeaders(
                 String.valueOf(body.length()), body));

--- a/src/test/java/httpserver/response/ResponseFormatterTest.java
+++ b/src/test/java/httpserver/response/ResponseFormatterTest.java
@@ -3,6 +3,9 @@ package httpserver.response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static httpserver.constants.HTTPLines.DEFAULT_VERSION;
 import static httpserver.constants.HTTPLines.SP;
@@ -13,15 +16,17 @@ class ResponseFormatterTest {
 
     @Test
     @DisplayName("Test if the response is formats correct startLine")
-    public void testIfResponseFormattedCorrectStartLine() {
+    public void testIfResponseFormattedCorrectStartLine() throws IOException {
         String body = "";
         String headers = "";
-        Response response = new Response(OK.code, headers, body);
+        Response response = new Response(OK.code, headers, body.getBytes());
         ResponseFormatter responseFormatter = new ResponseFormatter();
 
         String expectedResponse = DEFAULT_VERSION + SP + OK.code + CRLF + CRLF;
-
-        String formattedResponse = responseFormatter.formatResponse(response);
+        String formattedResponse =
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8);
         assertEquals(formattedResponse, expectedResponse);
     }
 }
+

--- a/src/test/java/httpserver/response/ResponseTest.java
+++ b/src/test/java/httpserver/response/ResponseTest.java
@@ -3,6 +3,8 @@ package httpserver.response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static httpserver.constants.StatusCode.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,7 +14,7 @@ class ResponseTest {
     @Test
     @DisplayName("Test if the status is 200 OK")
     public void testIfStatusOK() {
-        Response response = new Response(OK.code, "", "");
+        Response response = new Response(OK.code, "", "".getBytes());
         assertEquals(response.status, "200 OK");
     }
 
@@ -20,8 +22,11 @@ class ResponseTest {
     @DisplayName("Test if it returns the correct body")
     public void testIfBodyIsCorrect() {
         String body = "Some Body";
-        Response response = new Response(OK.code, "", body);
-        assertEquals(response.body, "Some Body");
+
+        Response response = new Response(OK.code, "", body.getBytes());
+        String responseBody = new String(response.body, StandardCharsets.UTF_8);
+
+        assertEquals(responseBody, "Some Body");
     }
 
     @Test
@@ -30,7 +35,7 @@ class ResponseTest {
         String body = "Some Body";
         String headers =
                 "Content-Type: 9" + CRLF + "Allow: GET, OPTIONS, HEAD" + CRLF;
-        Response response = new Response(OK.code, headers, body);
+        Response response = new Response(OK.code, headers, body.getBytes());
         assertEquals(response.headers, headers);
     }
 }

--- a/src/test/java/httpserver/router/RouterTest.java
+++ b/src/test/java/httpserver/router/RouterTest.java
@@ -8,6 +8,9 @@ import httpserver.response.ResponseFormatter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static httpserver.constants.HTTPLines.CRLF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,7 +18,7 @@ class RouterTest {
 
     @Test
     @DisplayName("Test if response 200 OK is sent")
-    public void testIfTheResponseIs200OK() {
+    public void testIfTheResponseIs200OK() throws IOException {
         RequestParser requestParser =
                 new RequestParser(TestUtils.mockRequestData());
         Request request = requestParser.parse();
@@ -24,14 +27,15 @@ class RouterTest {
         Response response = router.handleRequest(request);
         ResponseFormatter responseFormatter = new ResponseFormatter();
         String formattedResponse =
-                responseFormatter.formatResponse(response).split(CRLF)[0];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[0];
 
         assertEquals(formattedResponse, "HTTP/1.1 200 OK");
     }
 
     @Test
     @DisplayName("Test if response 404 was sent")
-    public void testIfTheNotFoundResponseSent() {
+    public void testIfTheNotFoundResponseSent() throws IOException {
         RequestParser requestParser =
                 new RequestParser(TestUtils.mock404Data());
         Request request = requestParser.parse();
@@ -40,8 +44,10 @@ class RouterTest {
         Response response = router.handleRequest(request);
         ResponseFormatter responseFormatter = new ResponseFormatter();
         String formattedResponse =
-                responseFormatter.formatResponse(response).split(CRLF)[0];
+                new String(responseFormatter.formatResponse(response),
+                        StandardCharsets.UTF_8).split(CRLF)[0];
 
         assertEquals(formattedResponse, "HTTP/1.1 404 Not Found");
     }
 }
+

--- a/src/test/java/httpserver/server/RunnableServerTest.java
+++ b/src/test/java/httpserver/server/RunnableServerTest.java
@@ -77,7 +77,8 @@ class RunnableServerTest {
     @DisplayName("Test if send data was called when parseMessage is called")
     public void testIfSendDataWasCalled() throws IOException {
         SocketMock socketMock = mock(SocketMock.class);
-        doNothing().when(socketMock).sendData(TestUtils.mockResponse());
+        doNothing().when(socketMock)
+                .sendData(TestUtils.mockResponse().getBytes());
 
         RunnableServer runnableServer = new RunnableServer(socketMock);
         runnableServer.parseClientMessage(TestUtils.mockRequestData(),

--- a/src/test/java/httpserver/server/SocketMock.java
+++ b/src/test/java/httpserver/server/SocketMock.java
@@ -11,7 +11,7 @@ public class SocketMock implements ISocket {
 
     public boolean connectionClosed = false;
     public InputStream reader;
-    public String dataSent;
+    public byte[] dataSent;
     public String receivedData;
 
     public Socket socket;
@@ -36,7 +36,7 @@ public class SocketMock implements ISocket {
     }
 
     @Override
-    public void sendData(String message) {
+    public void sendData(byte[] message) {
         this.dataSent = message;
     }
 


### PR DESCRIPTION
- Modified ResponseFormatter.formatResponse to have the responsibility to convert string data to bytes.
- Changed SocketWrapper.sendData to take in a parameter with the data type of byte[] 
- Modified Response to take in body with the datatype byte[]
- Modified ResponseBuilder.withBody to receive the body as a byte[]
- Modified some tests to convert the data returned from ResponseFormatter.formatResponse into a string.